### PR TITLE
Added the ability to pass different number of arguments to a function

### DIFF
--- a/doc/arithmetic_parser.md
+++ b/doc/arithmetic_parser.md
@@ -165,6 +165,13 @@ functions, and common mathematical variables
 
     Class implementation:
 
+        def log(x, y=10):
+            if math.isclose(y, 2, abs_tol=1e-15):
+                return math.log2(x)
+            if math.isclose(y, 10, abs_tol=1e-15):
+                return math.log10(x)
+            return math.log(x, y)
+
         class BasicArithmeticParser(ArithmeticParser):
             def customize(self):
                 import math
@@ -186,7 +193,8 @@ functions, and common mathematical variables
                 self.add_function("tanh", 1, math.tanh)
                 self.add_function("rad", 1, math.radians)
                 self.add_function("deg", 1, math.degrees)
-                self.add_function("ln", 1, math.log)
+                self.add_function("ln", 1, lambda x: math.log(x))
+                self.add_function("log", (1, 2), math.log) # Log function can accept one or two values
                 self.add_function("log2", 1, math.log2)
                 self.add_function("log10", 1, math.log10)
                 self.add_function("gcd", 2, math.gcd)

--- a/doc/developer_api.md
+++ b/doc/developer_api.md
@@ -9,8 +9,11 @@
 - `add_operator(operator_symbol, num_args, left_right_assoc, operator_function)`
 - `add_variable(variable, value)`
 - `add_function(function_name, num_args, function_method)`
-  - if a function can accept a variable number of arguments, pass `...` for the
-    `num_args` argument; see the `nhypot` function in the `BasicArithmeticParser`
+  - if a function can accept any number of arguments, pass `...` for the
+    `num_args` argument (see the [`nhypot`](https://github.com/pyparsing/plusminus/blob/master/plusminus/plusminus.py#L1117) function)
+  - if a function can accept different numbers of arguments, pass a tuple of all
+    possible numbers of arguments a function can have for the `num_args` argument
+    (see the `log` function)
 
 ### Parser parse/evaluation methods
 

--- a/plusminus/plusminus.py
+++ b/plusminus/plusminus.py
@@ -522,6 +522,18 @@ class ArithmeticParser:
                         "{!r} is not a recognized function".format(fn_name)
                     )
                 fn_spec = self.fn_map[fn_name]
+
+                if isinstance(fn_spec.arity, tuple):
+                    if not any(arit == len(fn_args) for arit in fn_spec.arity):
+                        raise TypeError(
+                    "{} takes {} {}, {} given".format(
+                            fn_name,
+                            " or ".join(str(ari) for ari in fn_spec.arity),
+                            ("arg", "args")[fn_spec.arity[-1] != 1],
+                            len(fn_args),
+                        )
+                    )
+
                 if fn_spec.arity not in (len(fn_args), ...):
                     raise TypeError(
                         "{} takes {} {}, {} given".format(
@@ -1082,6 +1094,14 @@ class ArithmeticParser:
         return ret
 
 
+def log(x, y=10):
+    if math.isclose(y, 2, abs_tol=1e-15):
+        return math.log2(x)
+    if math.isclose(y, 10, abs_tol=1e-15):
+        return math.log10(x)
+    return math.log(x, y)
+
+
 class BasicArithmeticParser(ArithmeticParser):
     def customize(self):
         import math
@@ -1103,7 +1123,8 @@ class BasicArithmeticParser(ArithmeticParser):
         self.add_function("tanh", 1, math.tanh)
         self.add_function("rad", 1, math.radians)
         self.add_function("deg", 1, math.degrees)
-        self.add_function("ln", 1, math.log)
+        self.add_function("ln", 1, lambda x: math.log(x))
+        self.add_function("log", (1, 2), math.log) # Log function can accept one or two values
         self.add_function("log2", 1, math.log2)
         self.add_function("log10", 1, math.log10)
         self.add_function("gcd", 2, math.gcd)


### PR DESCRIPTION
I added the ability to pass functions with different number of argument. With the new `log` function, if passed with one argument `x`, it computes `log(x, 10)`. If passed with two arguments `x` and `y`, it computes `log(x, y)` where `y` is the base.

This can be done by passing a tuple of numbers, representing the different numbers of arguments a function can have:

```python
def log(x, y=10):
    if math.isclose(y, 2, abs_tol=1e-15):
        return math.log2(x)
    if math.isclose(y, 10, abs_tol=1e-15):
        return math.log10(x)
    return math.log(x, y)

class BasicArithmeticParser(ArithmeticParser):
    def customize(self):
        import math

        super().customize()
        self.add_function("log", (1, 2), math.log) # Log function can accept one or two values
```

I also updated the documentation.