### PR TITLE
Some more bug fixes + floordiv operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The **plusminus** package provides a ready-to-run arithmetic parser and evaluator, based on [`pyparsing`](https://pyparsing-docs.readthedocs.io/en/latest/index.html)'s 
 [`infixNotation`](https://pyparsing-docs.readthedocs.io/en/latest/pyparsing.html#pyparsing.infixNotation) helper method.
 
-Strings containing 5-function arithmetic expressions can be parsed and evaluated using the [`BasicArithmeticParser`](https://github.com/pyparsing/plusminus/blob/master/doc/arithmetic_parser.md#the-core-basicarithmeticparser):
+Strings containing 6-function arithmetic expressions can be parsed and evaluated using the [`BasicArithmeticParser`](https://github.com/pyparsing/plusminus/blob/master/doc/arithmetic_parser.md#the-core-basicarithmeticparser):
 
 ```python
 from plusminus import BasicArithmeticParser
@@ -25,7 +25,7 @@ Arithmetic expressions are evaluated following standard rules for operator prece
     ∪ (set union)
     -
     **
-    * / × ÷ mod
+    * / // × ÷ mod
     + -
     < > <= >= == != ≠ ≤ ≥
     in ∈ ∉

--- a/doc/arithmetic_parser.md
+++ b/doc/arithmetic_parser.md
@@ -6,7 +6,7 @@
 
 
 ### Features:
-- 5-function arithmetic (`+`, `-` , `*`, `/`, `**`)
+- 6-function arithmetic (`+`, `-` , `*`, `/`, `//`, `**`)
 
 - Unicode math operators (`×`, `÷`, `≠`, `≤`, `≥`, `∧`, `∨`, `∩`, `∪`, `∈`, `∉`)
 
@@ -200,19 +200,19 @@ functions, and common mathematical variables
             self.add_function("rad", 1, math.radians)
             self.add_function("deg", 1, math.degrees)
             self.add_function("ln", 1, lambda x: math.log(x))
-            self.add_function("log", (1, 2), math.log) # Log function can accept one or two values
+            self.add_function("log", (1, 2), math.log) # log function can accept one or two values
             self.add_function("log2", 1, math.log2)
             self.add_function("log10", 1, math.log10)
             self.add_function("gcd", 2, math.gcd)
             self.add_function(
-                "lcm",
-                2,
-                (lambda a, b: int(abs(a) / math.gcd(a, b) * abs(b)) if a or b else 0),
+                "lcm", 2,
+                lambda a, b: abs(a*b) // math.gcd(a, b) if a or b else 0
             )
-            self.add_function("gamma", 2, math.gamma)
+            self.add_function("gamma", 1, math.gamma)
             self.add_function("hypot", ..., lambda *seq: sum(safe_pow(i, 2) for i in seq)**0.5)
             self.add_function("rnd", 0, random.random)
             self.add_function("randint", 2, random.randint)
+            self.add_function("sgn", 1, lambda x: 0 if _eq(x, 0, self.epsilon) else 1 if x > 0 else -1),
             self.add_operator("°", 1, ArithmeticParser.LEFT, math.radians)
             # avoid clash with '!=' operator
             factorial_operator = (~pp.Literal("!=") + "!").setName("!")

--- a/doc/arithmetic_parser_user_guide.md
+++ b/doc/arithmetic_parser_user_guide.md
@@ -6,13 +6,6 @@
 
 ### Operators
 
-      √   **   +   ==  ∉    ∧
-      ³   *    -   !=  ∩    or
-      ²   /    <   ≠   ∪    ∨
-      ⁻¹  mod  >   ≤   in   ?:
-      !   ×    <=  ≥   not  |absolute-value|
-      °   ÷    >=  ∈   and
-
 - 6-function arithmetic (`+`, `-`, `*`, `/`, `//`, `**`)
 
 - Unicode math operators (`×`, `÷`, `≠`, `≤`, `≥`, `∧` (`and`), `∨` (`or`), `∩`, `∪`, `∈`, `∉`)

--- a/doc/arithmetic_parser_user_guide.md
+++ b/doc/arithmetic_parser_user_guide.md
@@ -11,9 +11,9 @@
       ²   /    <   ≠   ∪    ∨
       ⁻¹  mod  >   ≤   in   ?:
       !   ×    <=  ≥   not  |absolute-value|
-      °   ÷    >=  ∈   and
+      °   ÷    >=  ∈   and  //
 
-- 5-function arithmetic (`+`, `-`, `*`, `/`, `**`)
+- 6-function arithmetic (`+`, `-`, `*`, `/`, `//`, `**`)
 
 - Unicode math operators (`×`, `÷`, `≠`, `≤`, `≥`, `∧` (`and`), `∨` (`or`), `∩`, `∪`, `∈`, `∉`)
 
@@ -72,7 +72,7 @@
     !    
     leading '-'
     **
-    * / × ÷ mod
+    * / // × ÷ mod
     + -
     < > <= >= == != ≠ ≤ ≥
     in, not in, ∈ ∉

--- a/doc/arithmetic_parser_user_guide.md
+++ b/doc/arithmetic_parser_user_guide.md
@@ -11,7 +11,7 @@
       ²   /    <   ≠   ∪    ∨
       ⁻¹  mod  >   ≤   in   ?:
       !   ×    <=  ≥   not  |absolute-value|
-      °   ÷    >=  ∈   and  //
+      °   ÷    >=  ∈   and
 
 - 6-function arithmetic (`+`, `-`, `*`, `/`, `//`, `**`)
 

--- a/doc/developer_api.md
+++ b/doc/developer_api.md
@@ -48,15 +48,14 @@ Defining an operator that is both unary and binary
 
 ### SECURITY WARNINGS
 
-  - Do not add functions that use or give access to `eval`, `exec`, `compile`, `import`, `subprocess`, 
-    `system`, or `Popen`!
+  - Do not add functions that use or give access to [`eval`](https://docs.python.org/3/library/functions.html#eval), [`exec`](https://docs.python.org/3/library/functions.html#exec), [`compile`](https://docs.python.org/3/library/functions.html#compile), [`import`](https://docs.python.org/3/reference/simple_stmts.html#import), [`subprocess`](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [`os`](https://docs.python.org/3/library/os.html#module-os)
   - If adding functions that start separate threads, limit the total number of threads that
     your parser will create at one time.
   - Be extremely careful if reading/writing to the file system
   - Take care when exposing access to an underlying database or server files
   - Some math functions may need to be constrained to avoid extended arithmetic processing (see 
-    `constrained_factorial()` in the `BasicArithmeticParser` for an example)
+    `constrained_factorial` in the [`BasicArithmeticParser`](https://github.com/pyparsing/plusminus/blob/master/doc/arithmetic_parser.md#the-core-basicarithmeticparser) as an example)
   - When populating web page elements with gathered input strings, be sure to escape potential quotation and control 
-    characters (see `bottle_repl.py` for an example)
+    characters (see [`bottle_repl.py`](https://github.com/pyparsing/plusminus/blob/master/plusminus/examples/bottle_repl.py) as an example)
   - Be aware that your functions may get called recursively, or in an
     endless loop

--- a/doc/developer_api.md
+++ b/doc/developer_api.md
@@ -9,7 +9,7 @@
 - `add_operator(operator_symbol, num_args, left_right_assoc, operator_function)`
 - `add_variable(variable, value)`
 - `add_function(function_name, num_args, function_method)`
-  - if a function can accept any number of arguments, pass `...` for the
+  - if a function can accept any number of arguments, pass [`...`](https://docs.python.org/3/library/constants.html#Ellipsis) for the
     `num_args` argument (see the [`hypot`](https://docs.python.org/3/library/math.html#math.hypot) function)
   - if a function can accept different numbers of arguments, pass a tuple of all
     possible numbers of arguments a function can have for the `num_args` argument
@@ -39,9 +39,12 @@ Adding a new operator
 
 Adding a new function
 
-Accessing evaluated results and variables from your code
-  parser['xyz'] = 100
-  parser.evaluate("√xyz") returns 10
+Accessing evaluated results and variables from your code:
+
+   ```python
+   parser['xyz'] = 100
+   parser.evaluate("√xyz") # Returns 10.0
+   ```
 
 Defining an operator that is both unary and binary
 

--- a/plusminus/plusminus.py
+++ b/plusminus/plusminus.py
@@ -554,7 +554,7 @@ class ArithmeticParser:
 
     def __init__(self):
         self.max_number_of_vars = 1000
-        self.max_var_memory = 10**6
+        self.max_var_memory = 10 ** 6
 
         self._added_operator_specs = []
         self._added_function_specs = {}

--- a/plusminus/plusminus.py
+++ b/plusminus/plusminus.py
@@ -479,6 +479,7 @@ class ArithmeticParser:
             "−": operator.sub,
             "*": safe_str_mult,
             "/": operator.truediv,
+            "//": operator.floordiv,
             "mod": operator.mod,
             "×": safe_str_mult,
             "÷": operator.truediv,
@@ -537,7 +538,7 @@ class ArithmeticParser:
                         )
                     )
 
-                if fn_spec.arity not in (len(fn_args), ...):
+                elif fn_spec.arity not in (len(fn_args), ...):
                     raise TypeError(
                         "{} takes {} {}, {} given".format(
                             fn_name,
@@ -553,16 +554,16 @@ class ArithmeticParser:
 
     def __init__(self):
         self.max_number_of_vars = 1000
-        self.max_var_memory = 10 ** 6
+        self.max_var_memory = 10**6
 
         self._added_operator_specs = []
         self._added_function_specs = {}
         self._base_operators = (
-            "** * / mod × ÷ + - < > <= >= == != ≠ ≤ ≥ ∈ ∉ ∩ ∪ in not and ∧ or ∨ ?:"
+            "** * // / mod × ÷ + - < > <= >= == != ≠ ≤ ≥ ∈ ∉ ∩ ∪ in not and ∧ or ∨ ?:"
         ).split()
         self._base_function_map = {
             "abs": FunctionSpec(abs, 1),
-            "round": FunctionSpec(round, 2),
+            "round": FunctionSpec(round, (1, 2)),
             "trunc": FunctionSpec(math.trunc, 1),
             "ceil": FunctionSpec(math.ceil, 1),
             "floor": FunctionSpec(math.floor, 1),
@@ -617,6 +618,7 @@ class ArithmeticParser:
         yield from self.get_parser().scanString(*args)
 
     def parse(self, *args, **kwargs):
+        """Parses an expression."""
         if _get_expression_depth(args[0]) > self.maximum_expression_depth:
             raise OverflowError("expression too deeply nested")
 
@@ -629,6 +631,7 @@ class ArithmeticParser:
             return parsed[0]
 
     def evaluate(self, arith_expression):
+        """Evaluates an expression and returns its result."""
         with _trimming_exception_traceback():
             parsed = self.parse(arith_expression, parseAll=True)
             return parsed.evaluate()
@@ -905,7 +908,7 @@ class ArithmeticParser:
         base_operator_specs = [
             ("**", 2, pp.opAssoc.LEFT, self.ExponentBinaryOp),
             (pp.oneOf("- −"), 1, pp.opAssoc.RIGHT, self.ArithmeticUnaryOp),
-            (pp.oneOf("* / mod × ÷"), 2, pp.opAssoc.LEFT, self.ArithmeticBinaryOp),
+            (pp.oneOf("* // / mod × ÷"), 2, pp.opAssoc.LEFT, self.ArithmeticBinaryOp),
             (pp.oneOf("+ - −"), 2, pp.opAssoc.LEFT, self.ArithmeticBinaryOp),
             (pp.oneOf("< > <= >= == != ≠ ≤ ≥"), 2, pp.opAssoc.LEFT, BinaryComparison),
             ((IN | NOT_IN | pp.oneOf("∈ ∉")) - (range_expression | set_expression | var_name), 1, pp.opAssoc.LEFT,


### PR DESCRIPTION
- `//` operator for [`floordiv`](https://docs.python.org/3/library/operator.html#operator.floordiv) added
- Fixed bug for functions that can accept several numbers of arguments, where [`TypeError`](https://docs.python.org/3/library/exceptions.html#TypeError) was always raised when called
- `round` function now accepts one or two arguments, instead of two
- Added small documentation for `ArithmeticParser().parse` and `ArithmeticParser().evaluate` functions